### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 WORKDIR /app
 COPY . /app/
 RUN apt-get update -y && apt-get install default-jdk -y


### PR DESCRIPTION
`debian` changed recently. This pull request ensures you're using the latest version of the image and changes `debian` to the latest tag: `12`

New base image: `debian:12`