### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  jfrog.fkinternal.com/fk-base-images-stage.local/debain:11.6
+FROM jfrog.fkinternal.com/fk-base-images-stage.local/debain:12
 WORKDIR /app
 COPY . /app/
 RUN apt-get update -y && apt-get install default-jdk -y


### PR DESCRIPTION
`jfrog.fkinternal.com/fk-base-images-stage.local/debain` changed recently. This pull request ensures you're using the latest version of the image and changes `jfrog.fkinternal.com/fk-base-images-stage.local/debain` to the latest tag: `12`

New base image: `jfrog.fkinternal.com/fk-base-images-stage.local/debain:12`