### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Java application
-FROM openjdk:11 AS build
+FROM openjdk:22-jdk-bookworm AS build
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ COPY ./src ./src
 RUN javac ./src/Main.java
 
 # Stage 2: Create a runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:22-jdk-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
`openjdk` changed recently. This pull request ensures you're using the latest version of the image and changes `openjdk` to the latest tag: `22-jdk-bookworm`

New base image: `openjdk:22-jdk-bookworm`